### PR TITLE
Get contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,38 @@ any other that may include `csw.default_custom_content` in it - see the source c
       Dynamic = 'custom.render_context_num'
     }
   ```
+- Get raw context info (use `get_contexts`)<br/>
+  Example:
+
+  ```lua
+    local csw = require('context-switch')
+    csw.setup()
+    -- Shows a box of the numbers of active contexts in numerical order
+    xplr.fn.custom.render_active_context_nums = function(ctx)
+      local res = ''
+      local contexts = csw.get_contexts()
+      for i = 1, 10 do
+        local index = i + 1
+        -- Context 0 will be shown as '10'
+        if i == 10 then
+          index = 1
+        end
+        -- If context is not empty, append its number to result with a space
+        if next(contexts[index]) ~= nil then
+          res = res .. tostring(i) .. ' '
+        end
+      end
+      return {
+        CustomParagraph = {
+          ui = {
+            title = { format = 'Contexts' }
+          },
+          body = res
+        }
+      }
+    end
+    -- and then somewhere in your layout use
+    {
+      Dynamic = 'custom.render_active_context_nums'
+    }
+  ```

--- a/init.lua
+++ b/init.lua
@@ -55,6 +55,10 @@ csw.get_current_context_num = function()
     return cur
 end
 
+csw.get_contexts = function()
+    return cs
+end
+
 local layout_height = 32
 
 csw.default_custom_content = {


### PR DESCRIPTION
I added a function, `csw.get_contexts()` that simply returns the contexts.

The reason I did this was because I wanted to emulate `nnn`'s way of showing the contexts, with numbers in the upper left corner that each correspond to a context that change colors to indicate they are "active." To do this, I needed a way to determine which contexts were not empty.

I also updated README.md with an example. It does not implement the exact functionality that motivated this, because the way I did it requires a different plugin to handle styling the numbers and I am not sure how else to implement it. The difference is that instead of starting with every context's number and changing colors of active contexts' numbers, it starts with no numbers and only shows the numbers of active contexts in numerical order (with context 0 represented with the number 10).